### PR TITLE
Add chunk capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,26 @@
 # skopeo-worker
 
-Skopeo-worker is a python wrapper script around [skopeo](https://github.com/containers/skopeo). It will periodically perform container mirror tasks as a job inside a kubernetes cluster. Used by our [helm-charts](https://github.com/osism/helm-charts). Can currently only work with quay.io and dockerhub.
+Skopeo-worker is a python wrapper script around [skopeo](https://github.com/containers/skopeo).
+It will periodically perform container mirror tasks as a job inside a kubernetes cluster.
+Used by our [helm-charts](https://github.com/osism/helm-charts). Can currently only work with quay.io and dockerhub.
 
 ## Environment variables
 
-There are two environment variables available to configure this wrapper. `MIRROR_SOURCE_URL` takes a full URL pointing to a config file on with the containers to be mirrored.
+There are four environment variables available to configure this wrapper. `MIRROR_SOURCE_URL` takes a full URL pointing to a config file on with the containers to be mirrored.
 The format of this file can be found in the next section. `MIRROR_DEST_URL` is the DNS name of your destination registry, which should hold your mirrors.
+
+`CHUNK_SIZE` and `CHUNK_NUMBER` are optional. It you define them, the script will split your list passed via `MIRROR_SOURCE_URL` into chunks and work only on a part of the list.
+This is especially handy if you have a large list of containers and therefore problems with api rate limits.
+
+When your list contains e.g. `["a", "b", "c", "d", "e", "f", "g", "h"]`, you can set `CHUNK_SIZE` to __3__ and `CHUNK_NUMBER` to __2__.
+This would result in a list containing `["d", "e", "f"]`. If you set `CHUNK_NUMBER` to __3__ the list would only contain `["g", "h"]`.
+Something out of range would just return an empty list `[]`.
 
 ```sh
 export MIRROR_SOURCE_URL="https://raw.githubusercontent.com/osism/sbom/main/mirrors.yaml"
 export MIRROR_DEST_URL="registry.airgap.services.osism.tech"
+export CHUNK_SIZE="0"
+export CHUNK_NUMBER="0"
 ```
 
 ## Config file example
@@ -22,7 +33,9 @@ containers:
 
 ## Kubernetes example
 
-To run skopeo-worker in Kubernetes, you might want to use a _CronJob_. An example might look like the code below. Keep in mind, that there are rate limits on the APIs. Consider splitting mirror source files into multiple and work on them at different time slots.
+To run skopeo-worker in Kubernetes, you might want to use a _CronJob_.
+An example might look like the code below. Keep in mind, that there are rate limits on the APIs.
+Consider using the chunk functionality and work on them at different time slots.
 
 ```yaml
 ---
@@ -31,7 +44,8 @@ kind: CronJob
 metadata:
   name: update-registry-mirror
 spec:
-  schedule:  "* */2 * * *"  # every two hours
+  schedule:  "* 2 * * *"  # every day at two o clock
+  concurrencyPolicy: Forbid  # Do not allow parallel containers
   jobTemplate:
     spec:
       template:
@@ -46,4 +60,8 @@ spec:
                   value: "https://raw.githubusercontent.com/osism/sbom/main/mirrors.yaml"
                 - name: MIRROR_DEST_URL
                   value: "registry.airgap.services.osism.tech"
+                - name: CHUNK_SIZE
+                  value: "50"
+                - name: CHUNK_NUMBER
+                  value: "5"
 ```

--- a/skopeo_mirror_wrapper.py
+++ b/skopeo_mirror_wrapper.py
@@ -7,6 +7,8 @@ import yaml
 
 mirror_source = os.getenv("MIRROR_SOURCE_URL", "https://raw.githubusercontent.com/osism/sbom/main/mirrors.yaml")
 mirror_dest = os.getenv("MIRROR_DEST_URL", "registry.airgap.services.osism.tech")
+chunk_size = int(os.getenv("CHUNK_SIZE", "0"))
+chunk_number = int(os.getenv("CHUNK_NUMBER", "0"))
 
 
 def load_yaml() -> dict:
@@ -16,7 +18,23 @@ def load_yaml() -> dict:
     except yaml.YAMLError as exc:
         print(exc)
 
-    return result['containers']
+    containers = []
+
+    # we are using chunks
+    if chunk_size > 0 and chunk_number > 0:
+        starting_point = chunk_size * (chunk_number - 1)  # substract one, to start at 0
+
+        counter = 0
+        while counter < chunk_size:
+            try:
+                containers.append(result['containers'][counter + starting_point])
+            except IndexError:
+                pass
+            counter = counter + 1
+    else:
+        containers = result['containers']
+
+    return containers
 
 
 def get_tags(reg: str, org: str, img: str) -> list:
@@ -92,3 +110,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
You can now define a chunk size and a chunk number to only work on a part of the given list and therefore avoid api rate limits.

Signed-off-by: Tim Beermann <beermann@osism.tech>
