### PR TITLE
Add filter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,31 @@ Used by our [helm-charts](https://github.com/osism/helm-charts). Can currently o
 
 ## Environment variables
 
-There are four environment variables available to configure this wrapper. `MIRROR_SOURCE_URL` takes a full URL pointing to a config file on with the containers to be mirrored.
-The format of this file can be found in the next section. `MIRROR_DEST_URL` is the DNS name of your destination registry, which should hold your mirrors.
+|Variable           |Mandatory|Description|
+|-------------------|---------|-----------|
+|`MIRROR_SOURCE_URL`| X       |Takes a full URL pointing to a [config file](https://raw.githubusercontent.com/osism/python-skopeo-wrapper/main/example_container_list.yaml) on with the containers to be mirrored.|
+|`MIRROR_DEST_URL`  | X       |The DNS name of your destination registry, which should hold your mirrors, e.g. `registry.airgap.services.osism.tech`.|
+|`CHUNK_SIZE`       |         |Requires `CHUNK_NUMBER`. Split list into a given amount of chunks with the size of _n_.|
+|`CHUNK_NUMBER`     |         |Requires `CHUNK_SIZE`. Split list into _n_ chunks with a given size. |
+|`FILTER`           |         |Python compatible regular expression. If there is a match on the container tag, it gets mirrored.|
+|`LIMIT`            |         |Amount of containers to be mirrored. Starting from the most recent.|
 
-`CHUNK_SIZE` and `CHUNK_NUMBER` are optional. It you define them, the script will split your list passed via `MIRROR_SOURCE_URL` into chunks and work only on a part of the list.
-This is especially handy if you have a large list of containers and therefore problems with api rate limits.
-
-When your list contains e.g. `["a", "b", "c", "d", "e", "f", "g", "h"]`, you can set `CHUNK_SIZE` to __3__ and `CHUNK_NUMBER` to __2__.
-This would result in a list containing `["d", "e", "f"]`. If you set `CHUNK_NUMBER` to __3__ the list would only contain `["g", "h"]`.
-Something out of range would just return an empty list `[]`.
+### Default values
 
 ```sh
 export MIRROR_SOURCE_URL="https://raw.githubusercontent.com/osism/sbom/main/mirrors.yaml"
 export MIRROR_DEST_URL="registry.airgap.services.osism.tech"
 export CHUNK_SIZE="0"
 export CHUNK_NUMBER="0"
+export FILTER=""
+export LIMIT="0"
 ```
+
+### Chunk detailed explanation
+
+When your list contains e.g. `["a", "b", "c", "d", "e", "f", "g", "h"]`, you can set `CHUNK_SIZE` to __3__ and `CHUNK_NUMBER` to __2__.
+This would result in a list containing `["d", "e", "f"]`. If you set `CHUNK_NUMBER` to __3__ the list would only contain `["g", "h"]`.
+Something out of range would just return an empty list `[]`.
 
 ## Config file example
 

--- a/example_container_list.yaml
+++ b/example_container_list.yaml
@@ -1,0 +1,4 @@
+---
+containers:
+  - quay.io/osism/homer
+  - registry-1.docker.io/library/mariadb

--- a/spec.yml
+++ b/spec.yml
@@ -1,0 +1,162 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: update-registry-mirror-1-of-6
+  namespace: registry
+spec:
+  schedule:  "* 1 * * *"  # every day at one o clock
+  concurrencyPolicy: Forbid  # Do not allow parallel containers
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: skopeo-worker
+              image: harbor.services.osism.tech/osism/skopeo-worker:latest
+              imagePullPolicy: Always
+              env:
+                - name: MIRROR_SOURCE_URL
+                  value: "https://raw.githubusercontent.com/osism/sbom/main/mirrors.yaml"
+                - name: MIRROR_DEST_URL
+                  value: "registry.airgap.services.osism.tech"
+                - name: CHUNK_SIZE
+                  value: "50"
+                - name: CHUNK_NUMBER
+                  value: "1"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: update-registry-mirror-2-of-6
+  namespace: registry
+spec:
+  schedule:  "* 5 * * *"  # every day at five o clock
+  concurrencyPolicy: Forbid  # Do not allow parallel containers
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: skopeo-worker
+              image: harbor.services.osism.tech/osism/skopeo-worker:latest
+              imagePullPolicy: Always
+              env:
+                - name: MIRROR_SOURCE_URL
+                  value: "https://raw.githubusercontent.com/osism/sbom/main/mirrors.yaml"
+                - name: MIRROR_DEST_URL
+                  value: "registry.airgap.services.osism.tech"
+                - name: CHUNK_SIZE
+                  value: "50"
+                - name: CHUNK_NUMBER
+                  value: "2"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: update-registry-mirror-3-of-6
+  namespace: registry
+spec:
+  schedule:  "* 9 * * *"  # every day at nine o clock
+  concurrencyPolicy: Forbid  # Do not allow parallel containers
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: skopeo-worker
+              image: harbor.services.osism.tech/osism/skopeo-worker:latest
+              imagePullPolicy: Always
+              env:
+                - name: MIRROR_SOURCE_URL
+                  value: "https://raw.githubusercontent.com/osism/sbom/main/mirrors.yaml"
+                - name: MIRROR_DEST_URL
+                  value: "registry.airgap.services.osism.tech"
+                - name: CHUNK_SIZE
+                  value: "50"
+                - name: CHUNK_NUMBER
+                  value: "3"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: update-registry-mirror-4-of-6
+  namespace: registry
+spec:
+  schedule:  "* 13 * * *"  # every day at 13 o clock
+  concurrencyPolicy: Forbid  # Do not allow parallel containers
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: skopeo-worker
+              image: harbor.services.osism.tech/osism/skopeo-worker:latest
+              imagePullPolicy: Always
+              env:
+                - name: MIRROR_SOURCE_URL
+                  value: "https://raw.githubusercontent.com/osism/sbom/main/mirrors.yaml"
+                - name: MIRROR_DEST_URL
+                  value: "registry.airgap.services.osism.tech"
+                - name: CHUNK_SIZE
+                  value: "50"
+                - name: CHUNK_NUMBER
+                  value: "4"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: update-registry-mirror-5-of-6
+  namespace: registry
+spec:
+  schedule:  "* 17 * * *"  # every day at 17 o clock
+  concurrencyPolicy: Forbid  # Do not allow parallel containers
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: skopeo-worker
+              image: harbor.services.osism.tech/osism/skopeo-worker:latest
+              imagePullPolicy: Always
+              env:
+                - name: MIRROR_SOURCE_URL
+                  value: "https://raw.githubusercontent.com/osism/sbom/main/mirrors.yaml"
+                - name: MIRROR_DEST_URL
+                  value: "registry.airgap.services.osism.tech"
+                - name: CHUNK_SIZE
+                  value: "50"
+                - name: CHUNK_NUMBER
+                  value: "5"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: update-registry-mirror-6-of-6
+  namespace: registry
+spec:
+  schedule:  "* 21 * * *"  # every day at 21 o clock
+  concurrencyPolicy: Forbid  # Do not allow parallel containers
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: skopeo-worker
+              image: harbor.services.osism.tech/osism/skopeo-worker:latest
+              imagePullPolicy: Always
+              env:
+                - name: MIRROR_SOURCE_URL
+                  value: "https://raw.githubusercontent.com/osism/sbom/main/mirrors.yaml"
+                - name: MIRROR_DEST_URL
+                  value: "registry.airgap.services.osism.tech"
+                - name: CHUNK_SIZE
+                  value: "50"
+                - name: CHUNK_NUMBER
+                  value: "6"


### PR DESCRIPTION
In order to reduce api requests, you can now use "LIMIT" to mirror only a certain amount of containers.
You can also use "FILTER" which should contain a python compatible regex pattern to match against the tags.
If there is a match, the tag is mirrored. You can even combine "LIMIT" and "FILTER".

Signed-off-by: Tim Beermann <beermann@osism.tech>
