### PR TITLE
Add proper logging mechanism

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML
+loguru
 requests


### PR DESCRIPTION
Avoid manual flushed to sys.stdout. Replace simple print statements with loguru logger.

Signed-off-by: Tim Beermann <beermann@osism.tech>
